### PR TITLE
Add advanced render settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,12 +41,21 @@ stop_event = threading.Event()
 
 
 class Scene:
-    def __init__(self, file, output_folder, frame_start, frame_end, prefix):
+    def __init__(self, file, output_folder, frame_start, frame_end, prefix,
+                 resolution_x=None, resolution_y=None, engine=None, samples=None,
+                 file_format=None, color_depth=None, fps=None):
         self.file = file
         self.output_folder = output_folder
         self.frame_start = frame_start
         self.frame_end = frame_end
         self.prefix = prefix
+        self.resolution_x = resolution_x
+        self.resolution_y = resolution_y
+        self.engine = engine
+        self.samples = samples
+        self.file_format = file_format
+        self.color_depth = color_depth
+        self.fps = fps
 
 
 def log(message: str):
@@ -74,6 +83,20 @@ def render_process(scene: Scene):
             '--frame-start', str(scene.frame_start),
             '--frame-end', str(scene.frame_end),
         ]
+        if scene.resolution_x is not None:
+            render_command += ['--resolution-x', str(scene.resolution_x)]
+        if scene.resolution_y is not None:
+            render_command += ['--resolution-y', str(scene.resolution_y)]
+        if scene.engine:
+            render_command += ['--engine', scene.engine]
+        if scene.samples is not None:
+            render_command += ['--samples', str(scene.samples)]
+        if scene.file_format:
+            render_command += ['--file-format', scene.file_format]
+        if scene.color_depth:
+            render_command += ['--color-depth', scene.color_depth]
+        if scene.fps is not None:
+            render_command += ['--fps', str(scene.fps)]
         log(f"[DEBUG] Render command: {' '.join(render_command)})")
         with subprocess.Popen(render_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True) as proc:
             for output_line in proc.stdout:
@@ -125,9 +148,26 @@ def add_scene():
         frame_end = int(request.form.get('frame_end', 0))
     except ValueError:
         return redirect(url_for('index'))
+    def opt_int(name):
+        val = request.form.get(name)
+        try:
+            return int(val) if val else None
+        except (TypeError, ValueError):
+            return None
+    resolution_x = opt_int('resolution_x')
+    resolution_y = opt_int('resolution_y')
+    samples = opt_int('samples')
+    fps = opt_int('fps')
+    engine = request.form.get('engine') or None
+    file_format = request.form.get('file_format') or None
+    color_depth = request.form.get('color_depth') or None
     if not scene_file:
         return redirect(url_for('index'))
-    scene_list.append(Scene(scene_file, output_folder, frame_start, frame_end, prefix))
+    scene_list.append(Scene(
+        scene_file, output_folder, frame_start, frame_end, prefix,
+        resolution_x=resolution_x, resolution_y=resolution_y,
+        engine=engine, samples=samples, file_format=file_format,
+        color_depth=color_depth, fps=fps))
     save_scene_list()
     return redirect(url_for('index'))
 

--- a/render_blender.py
+++ b/render_blender.py
@@ -11,6 +11,13 @@ def parse_args():
     parser.add_argument("--prefix", default="", help="Filename prefix")
     parser.add_argument("--frame-start", type=int, help="Start frame")
     parser.add_argument("--frame-end", type=int, help="End frame")
+    parser.add_argument("--resolution-x", type=int, help="Output resolution X")
+    parser.add_argument("--resolution-y", type=int, help="Output resolution Y")
+    parser.add_argument("--engine", help="Render engine (CYCLES, BLENDER_EEVEE, etc.)")
+    parser.add_argument("--samples", type=int, help="Render samples for Cycles/Eevee")
+    parser.add_argument("--file-format", help="Image file format e.g. PNG, JPEG")
+    parser.add_argument("--color-depth", help="Color depth e.g. 8 or 16")
+    parser.add_argument("--fps", type=int, help="Frames per second")
     args = parser.parse_args(sys.argv[sys.argv.index("--") + 1:])
     return args
 
@@ -23,10 +30,32 @@ def main():
         scene.frame_start = args.frame_start
     if args.frame_end is not None:
         scene.frame_end = args.frame_end
+
+    if args.resolution_x is not None:
+        scene.render.resolution_x = args.resolution_x
+    if args.resolution_y is not None:
+        scene.render.resolution_y = args.resolution_y
+    if args.engine:
+        scene.render.engine = args.engine
+    if args.fps is not None:
+        scene.render.fps = args.fps
+
     if not os.path.isdir(args.output_dir):
         os.makedirs(args.output_dir, exist_ok=True)
     scene.render.filepath = os.path.join(args.output_dir, args.prefix)
-    scene.render.image_settings.file_format = 'PNG'
+
+    if args.file_format:
+        scene.render.image_settings.file_format = args.file_format
+    else:
+        scene.render.image_settings.file_format = 'PNG'
+    if args.color_depth:
+        scene.render.image_settings.color_depth = args.color_depth
+    if args.samples is not None:
+        if scene.render.engine == 'CYCLES':
+            scene.cycles.samples = args.samples
+        elif scene.render.engine == 'BLENDER_EEVEE':
+            scene.eevee.taa_render_samples = args.samples
+
     bpy.ops.render.render(animation=True)
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -80,3 +80,8 @@ li {
     margin-bottom: 10px;
     font-weight: bold;
 }
+
+.details {
+    font-size: 0.9em;
+    color: #555;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,6 +15,30 @@
             <label>Filename Prefix:</label><input type="text" name="prefix" size="20"><br>
             <label>Frame Start:</label><input type="number" name="frame_start"><br>
             <label>Frame End:</label><input type="number" name="frame_end"><br>
+            <label>Resolution X:</label><input type="number" name="resolution_x"><br>
+            <label>Resolution Y:</label><input type="number" name="resolution_y"><br>
+            <label>Engine:</label>
+            <select name="engine">
+                <option value="">Default</option>
+                <option value="CYCLES">Cycles</option>
+                <option value="BLENDER_EEVEE">Eevee</option>
+            </select><br>
+            <label>Samples:</label><input type="number" name="samples"><br>
+            <label>File Format:</label>
+            <select name="file_format">
+                <option value="">Default</option>
+                <option value="PNG">PNG</option>
+                <option value="JPEG">JPEG</option>
+                <option value="TIFF">TIFF</option>
+                <option value="OPEN_EXR">OPEN_EXR</option>
+            </select><br>
+            <label>Color Depth:</label>
+            <select name="color_depth">
+                <option value="">Default</option>
+                <option value="8">8</option>
+                <option value="16">16</option>
+            </select><br>
+            <label>FPS:</label><input type="number" name="fps"><br>
             <input type="submit" value="Add Scene">
         </form>
         <h2>Scenes</h2>
@@ -22,6 +46,11 @@
             {% for s in scenes %}
             <li>
                 {{ s.file }} ({{ s.frame_start }}-{{ s.frame_end }})
+                <span class="details">
+                    {% if s.resolution_x and s.resolution_y %}{{ s.resolution_x }}x{{ s.resolution_y }} {% endif %}
+                    {% if s.engine %}{{ s.engine }} {% endif %}
+                    {% if s.file_format %}{{ s.file_format }}{% endif %}
+                </span>
                 <form action="/remove/{{ loop.index0 }}" method="post" style="display:inline;">
                     <button type="submit">Remove</button>
                 </form>


### PR DESCRIPTION
## Summary
- support more render options in `render_blender.py`
- pass new options from Flask backend
- parse the options from the web form
- enhance the web UI to show and collect these settings
- style scene details in the list

## Testing
- `python -m py_compile main.py render_blender.py settings.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687a66d049808325b23151260085f302